### PR TITLE
Explicitly send "quit" command when exiting.

### DIFF
--- a/src/android/jni/stockfishjni/stockfishjni.cpp
+++ b/src/android/jni/stockfishjni/stockfishjni.cpp
@@ -84,6 +84,7 @@ JNIEXPORT void JNICALL Java_org_lichess_stockfish_CordovaPluginStockfish_jniInit
 }
 
 JNIEXPORT void JNICALL Java_org_lichess_stockfish_CordovaPluginStockfish_jniExit(JNIEnv *env, jobject obj) {
+  UCI::command("quit");
   sync_cout << CMD_EXIT << sync_endl;
   reader.join();
   Threads.set(0);


### PR DESCRIPTION
This makes sure the uiThread is cleaned up when the
engine is no longer in use.