### PR TITLE
Size hashtable according to device RAM.

### DIFF
--- a/src/android/org.lichess.stockfish/CordovaPluginStockfish.java
+++ b/src/android/org.lichess.stockfish/CordovaPluginStockfish.java
@@ -2,6 +2,9 @@ package org.lichess.stockfish;
 
 import static java.util.concurrent.TimeUnit.*;
 
+import android.app.ActivityManager;
+import android.content.Context;
+
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -76,7 +79,13 @@ public final class CordovaPluginStockfish extends CordovaPlugin {
 
   private void init(CallbackContext callbackContext) {
     if(!isInit) {
-      jniInit();
+      // Get total device RAM for hashtable sizing
+      Context context = this.cordova.getActivity().getApplicationContext();
+      ActivityManager actManager = (ActivityManager) context.getSystemService(Context.ACTIVITY_SERVICE);
+      ActivityManager.MemoryInfo memInfo = new ActivityManager.MemoryInfo();
+      actManager.getMemoryInfo(memInfo);
+      long totalMemory = memInfo.totalMem;
+      jniInit(totalMemory);
       isInit = true;
     }
     callbackContext.success();
@@ -140,7 +149,7 @@ public final class CordovaPluginStockfish extends CordovaPlugin {
     sendOutput(output);
   }
 
-  public native void jniInit();
+  public native void jniInit(long memorySize);
 
   public native void jniExit();
 


### PR DESCRIPTION
Right now we always use the default hashtable size of Stockfish, which
is 16MB. A modern, multiprocessor phone is very fast and will fill such
a hashtable in seconds, making further search much less efficient.

Determine the device RAM when initializing the plugin and allocate the
hashtable to be 1/16th the usable device RAM.

For a 4GB RAM Android device, this means using about ~220MB hashtables.
For a 1GB one, this means about ~55MB, which seems reasonable.