### PR TITLE
Update iOS backend for Stockfish updates.

### DIFF
--- a/src/ios/CordovaPluginStockfishios.h
+++ b/src/ios/CordovaPluginStockfishios.h
@@ -57,8 +57,9 @@ namespace stockfishios
     Bitbases::init();
     Search::init();
     Pawns::init();
-    Threads.init();
-    Tablebases::init(Options["SyzygyPath"], CHESS_VARIANT);
+    Tablebases::init(CHESS_VARIANT, Options["SyzygyPath"]); // After Bitboards are set
+    Threads.set(Options["Threads"]);
+    Search::clear(); // After threads are up
     TT.resize(Options["Hash"]);
   }
 
@@ -69,6 +70,6 @@ namespace stockfishios
   void exit() {
     sync_cout << CMD_EXIT << sync_endl;
     reader.join();
-    Threads.exit();
+    Threads.set(0);
   }
 }


### PR DESCRIPTION
Change the initialization sequence to match the
Android version, and use the new Thread functions.

I'm not able to test this due to lack of iOS devices.